### PR TITLE
[feat] change model into stable diffusion v-1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 # 환경설정
 ```bash
-conda create -n {env_name} python=3.8
+conda create -n {env_name} python=3.10
 conda activate {env_name}
 git clone https://github.com/CompVis/latent-diffusion.git
 git clone https://github.com/CompVis/taming-transformers
 pip install -e ./taming-transformers
-cd latent-diffusion/
-mkdir models/ldm/txt2img-f8-large
-cd models/ldm/txt2img-f8-large
-apt-get install axel
-axel https://ommer-lab.com/files/latent-diffusion/nitro/txt2img-f8-large/model.ckpt
-pip install omegaconf>=2.0.0 pytorch-lightning>=1.7.7 torch-fidelity einops ldm-fix k-diffusion gradio pre-commit black transfomers
+wget https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt # sd v-1.5
+pip install omegaconf>=2.0.0 pytorch-lightning>=1.7.7 torch-fidelity einops ldm-fix k-diffusion gradio pre-commit black
+pip install transfomers
 pre-commit install
-cd /clone-sd-webui/
 apt-get install msttcorefonts # for font(arial.ttf)
 ```

--- a/main.py
+++ b/main.py
@@ -64,13 +64,13 @@ def parse_args():
     parser.add_argument(
         "--config",
         type=str,
-        default="latent-diffusion/configs/latent-diffusion/txt2img-1p4B-eval.yaml",
+        default="v1-inference.yaml",
         help="path to config which constructs model",
     )
     parser.add_argument(
         "--ckpt",
         type=str,
-        default="latent-diffusion/models/ldm/txt2img-f8-large/model.ckpt",
+        default="v1-5-pruned-emaonly.ckpt.1",
         help="path to checkpoint of model",
     )
     parser.add_argument("--device", type=str, default="cuda", help="accelerator")


### PR DESCRIPTION
기본 모델 변경 이유
- Community에서 주로 stable diffusion v-1.5를 사용
- 이에 따라 Textual inversion 또는 LORA 파일 등을 원활히 이용하기 위해 1028의 dimension을 갖는 모델이 아닌 768의 dimension을 갖는 sd_v-1.5로 변경